### PR TITLE
Uninitialized local variable ext

### DIFF
--- a/mcp_can.cpp
+++ b/mcp_can.cpp
@@ -1067,7 +1067,7 @@ INT8U MCP_CAN::sendMsgBuf(INT32U id, INT8U ext, INT8U len, INT8U *buf)
 *********************************************************************************************************/
 INT8U MCP_CAN::sendMsgBuf(INT32U id, INT8U len, INT8U *buf)
 {
-    INT8U ext, rtr = 0;
+    INT8U ext = 0, rtr = 0;
     INT8U res;
     
     if((id & 0x80000000) == 0x80000000)


### PR DESCRIPTION
Hello, 
I think I spotted a possible bug:
local variable ext is uninitialized in public function INT8U MCP_CAN::sendMsgBuf(INT32U id, INT8U len, INT8U *buf).
That could lead to wrong type of message id of the intended CAN message. 
 I'd be happy to receive your comments :)