### PR TITLE
Improved sleep functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Using the setMode() function the sketch can now put the protocol controller into
 
 User can enable and disable (default) One-Shot transmission mode from the sketch using enOneShotTX() or disOneShotTX() respectively.
 
+To wake up from CAN bus activity while in sleep mode enable the wake up interrupt with setSleepWakeup(1). Passing 0 will disable the wakeup interrupt (default).
+
 Installation
 ==============
 Copy this into the "[.../MySketches/]libraries/" folder and restart the Arduino editor.

--- a/examples/CAN_sleep/CAN_sleep.ino
+++ b/examples/CAN_sleep/CAN_sleep.ino
@@ -1,0 +1,107 @@
+// CAN Sleep Example
+// By Zak Kemble, based on the CAN receive example
+
+// If you only have 2 devices on the CAN bus (the device running this sketch and some other device sending messages), then you may find that duplicate messages are received when waking up.
+// This is because when the MCP2515 wakes up it enters LISTENONLY mode where it does not send ACKs to messages, so the transmitter will retransmit the same message a few times.
+
+#include <mcp_can.h>
+#include <SPI.h>
+#include <avr/sleep.h>
+
+#define CAN0_INT 2 // Set INT to pin 2
+MCP_CAN CAN0(10); // Set CS to pin 10
+
+void setup()
+{
+	Serial.begin(115200);
+
+	// Initialize MCP2515 running at 16MHz with a baudrate of 500kb/s and the masks and filters disabled.
+	if(CAN0.begin(MCP_ANY, CAN_500KBPS, MCP_16MHZ) == CAN_OK)
+		Serial.println(F("MCP2515 Initialized Successfully!"));
+	else
+		Serial.println(F("Error Initializing MCP2515..."));
+
+	CAN0.setMode(MCP_NORMAL); // Set operation mode to normal so the MCP2515 sends acks to received data.
+	CAN0.setSleepWakeup(1); // Enable wake up interrupt when in sleep mode
+
+	pinMode(CAN0_INT, INPUT); // Configuring pin for /INT input
+
+	// Enable interrupts for the CAN0_INT pin (should be pin 2 or 3 for Uno and other ATmega328P based boards)
+	attachInterrupt(digitalPinToInterrupt(CAN0_INT), ISR_CAN, FALLING);
+
+	set_sleep_mode(SLEEP_MODE_PWR_DOWN);
+
+	Serial.println(F("MCP2515 Library Sleep Example..."));
+}
+
+void loop()
+{
+	if(!digitalRead(CAN0_INT)) // If CAN0_INT pin is low, read receive buffer
+	{
+		unsigned long rxId;
+		byte len;
+		byte rxBuf[8];
+
+		if(CAN0.readMsgBuf(&rxId, &len, rxBuf) == CAN_OK) // Read data: len = data length, buf = data byte(s)
+		{
+			char msgString[128]; // Array to store serial string
+			if(rxId & CAN_IS_EXTENDED) // Determine if ID is standard (11 bits) or extended (29 bits)
+				sprintf_P(msgString, PSTR("Extended ID: 0x%.8lX  DLC: %1d  Data:"), (rxId & CAN_EXTENDED_ID), len);
+			else
+				sprintf_P(msgString, PSTR("Standard ID: 0x%.3lX       DLC: %1d  Data:"), rxId, len);
+
+			Serial.print(msgString);
+
+			if(rxId & CAN_IS_REMOTE_REQUEST) // Determine if message is a remote request frame.
+				Serial.print(F(" REMOTE REQUEST FRAME"));
+			else
+			{
+				for(byte i=0;i<len;i++)
+				{
+					sprintf_P(msgString, PSTR(" 0x%.2X"), rxBuf[i]);
+					Serial.print(msgString);
+				}
+			}
+			
+			Serial.println();
+		}
+		else
+			Serial.println(F("Interrupt is asserted, but there were no messages to process..."));
+	}
+	
+	Serial.println(F("SLEEPING..."));
+
+	// Put MCP2515 into sleep mode
+	// This can sometimes take upto around 100ms depending on what the chip is currently doing
+	CAN0.setMode(MCP_SLEEP);
+
+	Serial.println(F("SLEEP"));
+
+	// Clear serial buffers before sleeping
+	Serial.flush();
+
+	// Put the microcontroller to sleep
+	cli(); // Disable interrupts
+	if(digitalRead(CAN0_INT)) // Make sure we havn't missed an interrupt between the digitalRead() above and now. If an interrupt happens between now and sei()/sleep_cpu() then sleep_cpu() will immediately wake up again
+	{
+		sleep_enable();
+		sleep_bod_disable();
+		sei();
+		sleep_cpu();
+		sleep_disable();
+	}
+	sei();
+
+	Serial.println(F("WAKE"));
+
+	CAN0.setMode(MCP_NORMAL); // When the MCP2515 wakes up it will be in LISTENONLY mode, here we put it into NORMAL mode
+}
+
+static void ISR_CAN()
+{
+	// We don't do anything here, this is just for waking up the microcontroller
+}
+
+/*********************************************************************************************************
+  END FILE
+*********************************************************************************************************/

--- a/mcp_can.cpp
+++ b/mcp_can.cpp
@@ -492,24 +492,24 @@ INT8U MCP_CAN::mcp2515_init(const INT8U canIDMode, const INT8U canSpeed, const I
     if(res > 0)
     {
 #if DEBUG_MODE
-      Serial.print("Entering Configuration Mode Failure...\r\n"); 
+      Serial.println(F("Entering Configuration Mode Failure...")); 
 #endif
       return res;
     }
 #if DEBUG_MODE
-    Serial.print("Entering Configuration Mode Successful!\r\n");
+    Serial.println(F("Entering Configuration Mode Successful!"));
 #endif
 
     // Set Baudrate
     if(mcp2515_configRate(canSpeed, canClock))
     {
 #if DEBUG_MODE
-      Serial.print("Setting Baudrate Failure...\r\n");
+      Serial.println(F("Setting Baudrate Failure..."));
 #endif
       return res;
     }
 #if DEBUG_MODE
-    Serial.print("Setting Baudrate Successful!\r\n");
+    Serial.println(F("Setting Baudrate Successful!"));
 #endif
 
     if ( res == MCP2515_OK ) {
@@ -556,7 +556,7 @@ INT8U MCP_CAN::mcp2515_init(const INT8U canIDMode, const INT8U canSpeed, const I
     
             default:
 #if DEBUG_MODE        
-            Serial.print("`Setting ID Mode Failure...\r\n");
+            Serial.println(F("`Setting ID Mode Failure..."));
 #endif           
             return MCP2515_FAIL;
             break;
@@ -567,7 +567,7 @@ INT8U MCP_CAN::mcp2515_init(const INT8U canIDMode, const INT8U canSpeed, const I
         if(res)
         {
 #if DEBUG_MODE        
-          Serial.print("Returning to Previous Mode Failure...\r\n");
+          Serial.println(F("Returning to Previous Mode Failure..."));
 #endif           
           return res;
         }
@@ -769,12 +769,12 @@ INT8U MCP_CAN::init_Mask(INT8U num, INT8U ext, INT32U ulData)
 {
     INT8U res = MCP2515_OK;
 #if DEBUG_MODE
-    Serial.print("Starting to Set Mask!\r\n");
+    Serial.println(F("Starting to Set Mask!"));
 #endif
     res = mcp2515_setCANCTRL_Mode(MODE_CONFIG);
     if(res > 0){
 #if DEBUG_MODE
-    Serial.print("Entering Configuration Mode Failure...\r\n"); 
+    Serial.println(F("Entering Configuration Mode Failure...")); 
 #endif
   return res;
 }
@@ -791,12 +791,13 @@ INT8U MCP_CAN::init_Mask(INT8U num, INT8U ext, INT32U ulData)
     res = mcp2515_setCANCTRL_Mode(mcpMode);
     if(res > 0){
 #if DEBUG_MODE
-    Serial.print("Entering Previous Mode Failure...\r\nSetting Mask Failure...\r\n"); 
+    Serial.println(F("Entering Previous Mode Failure...")); 
+	Serial.println(F("Setting Mask Failure..."));
 #endif
     return res;
   }
 #if DEBUG_MODE
-    Serial.print("Setting Mask Successful!\r\n");
+    Serial.println(F("Setting Mask Successful!"));
 #endif
     return res;
 }
@@ -810,12 +811,12 @@ INT8U MCP_CAN::init_Mask(INT8U num, INT32U ulData)
     INT8U res = MCP2515_OK;
     INT8U ext = 0;
 #if DEBUG_MODE
-    Serial.print("Starting to Set Mask!\r\n");
+    Serial.println(F("Starting to Set Mask!"));
 #endif
     res = mcp2515_setCANCTRL_Mode(MODE_CONFIG);
     if(res > 0){
 #if DEBUG_MODE
-    Serial.print("Entering Configuration Mode Failure...\r\n"); 
+    Serial.println(F("Entering Configuration Mode Failure...")); 
 #endif
   return res;
 }
@@ -835,12 +836,13 @@ INT8U MCP_CAN::init_Mask(INT8U num, INT32U ulData)
     res = mcp2515_setCANCTRL_Mode(mcpMode);
     if(res > 0){
 #if DEBUG_MODE
-    Serial.print("Entering Previous Mode Failure...\r\nSetting Mask Failure...\r\n"); 
+    Serial.println(F("Entering Previous Mode Failure...")); 
+	Serial.println(F("Setting Mask Failure..."));
 #endif
     return res;
   }
 #if DEBUG_MODE
-    Serial.print("Setting Mask Successful!\r\n");
+    Serial.println(F("Setting Mask Successful!"));
 #endif
     return res;
 }
@@ -853,13 +855,13 @@ INT8U MCP_CAN::init_Filt(INT8U num, INT8U ext, INT32U ulData)
 {
     INT8U res = MCP2515_OK;
 #if DEBUG_MODE
-    Serial.print("Starting to Set Filter!\r\n");
+    Serial.println(F("Starting to Set Filter!"));
 #endif
     res = mcp2515_setCANCTRL_Mode(MODE_CONFIG);
     if(res > 0)
     {
 #if DEBUG_MODE
-      Serial.print("Enter Configuration Mode Failure...\r\n"); 
+      Serial.println(F("Enter Configuration Mode Failure...")); 
 #endif
       return res;
     }
@@ -898,12 +900,13 @@ INT8U MCP_CAN::init_Filt(INT8U num, INT8U ext, INT32U ulData)
     if(res > 0)
     {
 #if DEBUG_MODE
-      Serial.print("Entering Previous Mode Failure...\r\nSetting Filter Failure...\r\n"); 
+    Serial.println(F("Entering Previous Mode Failure...")); 
+	Serial.println(F("Setting Filter Failure..."));
 #endif
       return res;
     }
 #if DEBUG_MODE
-    Serial.print("Setting Filter Successfull!\r\n");
+    Serial.println(F("Setting Filter Successfull!"));
 #endif
     
     return res;
@@ -919,13 +922,13 @@ INT8U MCP_CAN::init_Filt(INT8U num, INT32U ulData)
     INT8U ext = 0;
     
 #if DEBUG_MODE
-    Serial.print("Starting to Set Filter!\r\n");
+    Serial.println(F("Starting to Set Filter!"));
 #endif
     res = mcp2515_setCANCTRL_Mode(MODE_CONFIG);
     if(res > 0)
     {
 #if DEBUG_MODE
-      Serial.print("Enter Configuration Mode Failure...\r\n"); 
+      Serial.println(F("Enter Configuration Mode Failure...")); 
 #endif
       return res;
     }
@@ -967,12 +970,13 @@ INT8U MCP_CAN::init_Filt(INT8U num, INT32U ulData)
     if(res > 0)
     {
 #if DEBUG_MODE
-      Serial.print("Entering Previous Mode Failure...\r\nSetting Filter Failure...\r\n"); 
+    Serial.println(F("Entering Previous Mode Failure...")); 
+	Serial.println(F("Setting Filter Failure..."));
 #endif
       return res;
     }
 #if DEBUG_MODE
-    Serial.print("Setting Filter Successfull!\r\n");
+    Serial.println(F("Setting Filter Successfull!"));
 #endif
     
     return res;

--- a/mcp_can.h
+++ b/mcp_can.h
@@ -71,6 +71,7 @@ class MCP_CAN
 
     INT8U mcp2515_readStatus(void);                                     // Read MCP2515 Status
     INT8U mcp2515_setCANCTRL_Mode(const INT8U newmode);                 // Set mode
+	INT8U mcp2515_requestNewMode(const INT8U newmode);                  // Set mode
     INT8U mcp2515_configRate(const INT8U canSpeed,                      // Set baudrate
                              const INT8U canClock);
                              

--- a/mcp_can.h
+++ b/mcp_can.h
@@ -110,6 +110,7 @@ public:
     INT8U init_Mask(INT8U num, INT32U ulData);                          // Initilize Mask(s)
     INT8U init_Filt(INT8U num, INT8U ext, INT32U ulData);               // Initilize Filter(s)
     INT8U init_Filt(INT8U num, INT32U ulData);                          // Initilize Filter(s)
+	void setSleepWakeup(INT8U enable);                                  // Enable or disable the wake up interrupt (If disabled the MCP2515 will not be woken up by CAN bus activity)
     INT8U setMode(INT8U opMode);                                        // Set operational mode
     INT8U sendMsgBuf(INT32U id, INT8U ext, INT8U len, INT8U *buf);      // Send message to transmit buffer
     INT8U sendMsgBuf(INT32U id, INT8U len, INT8U *buf);                 // Send message to transmit buffer

--- a/mcp_can_dfs.h
+++ b/mcp_can_dfs.h
@@ -462,6 +462,10 @@
 
 #define CAN_MAX_CHAR_IN_MESSAGE (8)
 
+#define CAN_IS_EXTENDED       0x80000000
+#define CAN_IS_REMOTE_REQUEST 0x40000000
+#define CAN_EXTENDED_ID       0x1FFFFFFF
+
 #endif
 /*********************************************************************************************************
   END FILE


### PR DESCRIPTION
Hey Cory, thanks for maintaining this library!

Entering and exiting sleep mode is kinda wack compared with other modes. Need to spam the mode request and read from the CAN STATUS register until the mode change is complete.

Manually exiting sleep mode requires turning on the wake interrupt and setting the wake interrupt flag. This trick was found at https://github.com/mkleemann/can/blob/master/can_sleep_mcp2515.c

Also used the F() macro to keep the debugging strings in flash.