### PR TITLE
Allow zero-length frames

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+This version has been modified to allow for zero-length (viz. header-only) CAN messages.
+These are used with the RTR bit set when querying a CAN network for the CAN_IDs of other modules.
+
 Sub-Development branch was copied to Master on June 30th, 2016.
 ==============
 

--- a/mcp_can.cpp
+++ b/mcp_can.cpp
@@ -2,10 +2,14 @@
   mcp_can.cpp
   2012 Copyright (c) Seeed Technology Inc.  All right reserved.
   2014 Copyright (c) Cory J. Fowler  All Rights Reserved.
+  2017 Copyright (c) David W. Radcliffe  All Rights Reserved.
 
   Author: Loovee
   Contributor: Cory J. Fowler
   2014-9-16
+  Contributor: David W. Radcliffe
+  2017-8-9
+
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
   License as published by the Free Software Foundation; either
@@ -30,7 +34,7 @@
 ** Function name:           mcp2515_reset
 ** Descriptions:            Performs a software reset
 *********************************************************************************************************/
-void MCP_CAN::mcp2515_reset(void)                                      
+void MCP_CAN::mcp2515_reset(void)
 {
     MCP2515_SELECT();
     spi_readwrite(MCP_RESET);
@@ -42,7 +46,7 @@ void MCP_CAN::mcp2515_reset(void)
 ** Function name:           mcp2515_readRegister
 ** Descriptions:            Read data register
 *********************************************************************************************************/
-INT8U MCP_CAN::mcp2515_readRegister(const INT8U address)                                                                     
+INT8U MCP_CAN::mcp2515_readRegister(const INT8U address)
 {
     INT8U ret;
 
@@ -66,7 +70,7 @@ void MCP_CAN::mcp2515_readRegisterS(const INT8U address, INT8U values[], const I
     spi_readwrite(MCP_READ);
     spi_readwrite(address);
     // mcp2515 has auto-increment of address-pointer
-    for (i=0; i<n; i++) 
+    for (i=0; i<n; i++)
         values[i] = spi_read();
 
     MCP2515_UNSELECT();
@@ -96,10 +100,10 @@ void MCP_CAN::mcp2515_setRegisterS(const INT8U address, const INT8U values[], co
     MCP2515_SELECT();
     spi_readwrite(MCP_WRITE);
     spi_readwrite(address);
-       
-    for (i=0; i<n; i++) 
+
+    for (i=0; i<n; i++)
         spi_readwrite(values[i]);
-	
+
     MCP2515_UNSELECT();
     //delayMicroseconds(250);
 }
@@ -123,7 +127,7 @@ void MCP_CAN::mcp2515_modifyRegister(const INT8U address, const INT8U mask, cons
 ** Function name:           mcp2515_readStatus
 ** Descriptions:            Reads status register
 *********************************************************************************************************/
-INT8U MCP_CAN::mcp2515_readStatus(void)                             
+INT8U MCP_CAN::mcp2515_readStatus(void)
 {
     INT8U i;
     MCP2515_SELECT();
@@ -156,7 +160,7 @@ INT8U MCP_CAN::mcp2515_setCANCTRL_Mode(const INT8U newmode)
     i = mcp2515_readRegister(MCP_CANCTRL);
     i &= MODE_MASK;
 
-    if ( i == newmode ) 
+    if ( i == newmode )
         return MCP2515_OK;
 
     return MCP2515_FAIL;
@@ -166,40 +170,40 @@ INT8U MCP_CAN::mcp2515_setCANCTRL_Mode(const INT8U newmode)
 ** Function name:           mcp2515_configRate
 ** Descriptions:            Set baudrate
 *********************************************************************************************************/
-INT8U MCP_CAN::mcp2515_configRate(const INT8U canSpeed, const INT8U canClock)            
+INT8U MCP_CAN::mcp2515_configRate(const INT8U canSpeed, const INT8U canClock)
 {
     INT8U set, cfg1, cfg2, cfg3;
     set = 1;
     switch (canClock)
     {
         case (MCP_8MHZ):
-        switch (canSpeed) 
+        switch (canSpeed)
         {
-            case (CAN_5KBPS):                                               //   5KBPS                  
+            case (CAN_5KBPS):                                               //   5KBPS
             cfg1 = MCP_8MHz_5kBPS_CFG1;
             cfg2 = MCP_8MHz_5kBPS_CFG2;
             cfg3 = MCP_8MHz_5kBPS_CFG3;
             break;
 
-            case (CAN_10KBPS):                                              //  10KBPS                  
+            case (CAN_10KBPS):                                              //  10KBPS
             cfg1 = MCP_8MHz_10kBPS_CFG1;
             cfg2 = MCP_8MHz_10kBPS_CFG2;
             cfg3 = MCP_8MHz_10kBPS_CFG3;
             break;
 
-            case (CAN_20KBPS):                                              //  20KBPS                  
+            case (CAN_20KBPS):                                              //  20KBPS
             cfg1 = MCP_8MHz_20kBPS_CFG1;
             cfg2 = MCP_8MHz_20kBPS_CFG2;
             cfg3 = MCP_8MHz_20kBPS_CFG3;
             break;
 
-            case (CAN_31K25BPS):                                            //  31.25KBPS                  
+            case (CAN_31K25BPS):                                            //  31.25KBPS
             cfg1 = MCP_8MHz_31k25BPS_CFG1;
             cfg2 = MCP_8MHz_31k25BPS_CFG2;
             cfg3 = MCP_8MHz_31k25BPS_CFG3;
             break;
 
-            case (CAN_33K3BPS):                                             //  33.33KBPS                  
+            case (CAN_33K3BPS):                                             //  33.33KBPS
             cfg1 = MCP_8MHz_33k3BPS_CFG1;
             cfg2 = MCP_8MHz_33k3BPS_CFG2;
             cfg3 = MCP_8MHz_33k3BPS_CFG3;
@@ -252,12 +256,12 @@ INT8U MCP_CAN::mcp2515_configRate(const INT8U canSpeed, const INT8U canClock)
             cfg2 = MCP_8MHz_500kBPS_CFG2;
             cfg3 = MCP_8MHz_500kBPS_CFG3;
             break;
-        
+
             case (CAN_1000KBPS):                                            //   1Mbps
             cfg1 = MCP_8MHz_1000kBPS_CFG1;
             cfg2 = MCP_8MHz_1000kBPS_CFG2;
             cfg3 = MCP_8MHz_1000kBPS_CFG3;
-            break;  
+            break;
 
             default:
             set = 0;
@@ -267,7 +271,7 @@ INT8U MCP_CAN::mcp2515_configRate(const INT8U canSpeed, const INT8U canClock)
         break;
 
         case (MCP_16MHZ):
-        switch (canSpeed) 
+        switch (canSpeed)
         {
             case (CAN_5KBPS):                                               //   5Kbps
             cfg1 = MCP_16MHz_5kBPS_CFG1;
@@ -339,12 +343,12 @@ INT8U MCP_CAN::mcp2515_configRate(const INT8U canSpeed, const INT8U canClock)
             cfg2 = MCP_16MHz_500kBPS_CFG2;
             cfg3 = MCP_16MHz_500kBPS_CFG3;
             break;
-        
+
             case (CAN_1000KBPS):                                            //   1Mbps
             cfg1 = MCP_16MHz_1000kBPS_CFG1;
             cfg2 = MCP_16MHz_1000kBPS_CFG2;
             cfg3 = MCP_16MHz_1000kBPS_CFG3;
-            break;  
+            break;
 
             default:
             set = 0;
@@ -352,9 +356,9 @@ INT8U MCP_CAN::mcp2515_configRate(const INT8U canSpeed, const INT8U canClock)
             break;
         }
         break;
-        
+
         case (MCP_20MHZ):
-        switch (canSpeed) 
+        switch (canSpeed)
         {
             case (CAN_40KBPS):                                              //  40Kbps
             cfg1 = MCP_20MHz_40kBPS_CFG1;
@@ -403,12 +407,12 @@ INT8U MCP_CAN::mcp2515_configRate(const INT8U canSpeed, const INT8U canClock)
             cfg2 = MCP_20MHz_500kBPS_CFG2;
             cfg3 = MCP_20MHz_500kBPS_CFG3;
             break;
-        
+
             case (CAN_1000KBPS):                                            //   1Mbps
             cfg1 = MCP_20MHz_1000kBPS_CFG1;
             cfg2 = MCP_20MHz_1000kBPS_CFG2;
             cfg3 = MCP_20MHz_1000kBPS_CFG3;
-            break;  
+            break;
 
             default:
             set = 0;
@@ -416,7 +420,7 @@ INT8U MCP_CAN::mcp2515_configRate(const INT8U canSpeed, const INT8U canClock)
             break;
         }
         break;
-        
+
         default:
         set = 0;
 	return MCP2515_FAIL;
@@ -429,7 +433,7 @@ INT8U MCP_CAN::mcp2515_configRate(const INT8U canSpeed, const INT8U canClock)
         mcp2515_setRegister(MCP_CNF3, cfg3);
         return MCP2515_OK;
     }
-     
+
     return MCP2515_FAIL;
 }
 
@@ -440,15 +444,15 @@ INT8U MCP_CAN::mcp2515_configRate(const INT8U canSpeed, const INT8U canClock)
 void MCP_CAN::mcp2515_initCANBuffers(void)
 {
     INT8U i, a1, a2, a3;
-    
-    INT8U std = 0;               
+
+    INT8U std = 0;
     INT8U ext = 1;
     INT32U ulMask = 0x00, ulFilt = 0x00;
 
 
     mcp2515_write_mf(MCP_RXM0SIDH, ext, ulMask);			/*Set both masks to 0           */
     mcp2515_write_mf(MCP_RXM1SIDH, ext, ulMask);			/*Mask register ignores ext bit */
-    
+
                                                                         /* Set all filters to 0         */
     mcp2515_write_mf(MCP_RXF0SIDH, ext, ulFilt);			/* RXB0: extended               */
     mcp2515_write_mf(MCP_RXF1SIDH, std, ulFilt);			/* RXB1: standard               */
@@ -485,14 +489,14 @@ INT8U MCP_CAN::mcp2515_init(const INT8U canIDMode, const INT8U canSpeed, const I
   INT8U res;
 
     mcp2515_reset();
-    
+
     mcpMode = MCP_LOOPBACK;
 
     res = mcp2515_setCANCTRL_Mode(MODE_CONFIG);
     if(res > 0)
     {
 #if DEBUG_MODE
-      Serial.print("Entering Configuration Mode Failure...\r\n"); 
+      Serial.print("Entering Configuration Mode Failure...\r\n");
 #endif
       return res;
     }
@@ -530,7 +534,7 @@ INT8U MCP_CAN::mcp2515_init(const INT8U canIDMode, const INT8U canSpeed, const I
             MCP_RXB_RX_ANY);
             break;
 /*          The followingn two functions of the MCP2515 do not work, there is a bug in the silicon.
-            case (MCP_STD): 
+            case (MCP_STD):
             mcp2515_modifyRegister(MCP_RXB0CTRL,
             MCP_RXB_RX_MASK | MCP_RXB_BUKT_MASK,
             MCP_RXB_RX_STD | MCP_RXB_BUKT_MASK );
@@ -538,7 +542,7 @@ INT8U MCP_CAN::mcp2515_init(const INT8U canIDMode, const INT8U canSpeed, const I
             MCP_RXB_RX_STD);
             break;
 
-            case (MCP_EXT): 
+            case (MCP_EXT):
             mcp2515_modifyRegister(MCP_RXB0CTRL,
             MCP_RXB_RX_MASK | MCP_RXB_BUKT_MASK,
             MCP_RXB_RX_EXT | MCP_RXB_BUKT_MASK );
@@ -546,29 +550,29 @@ INT8U MCP_CAN::mcp2515_init(const INT8U canIDMode, const INT8U canSpeed, const I
             MCP_RXB_RX_EXT);
             break;
 */
-            case (MCP_STDEXT): 
+            case (MCP_STDEXT):
             mcp2515_modifyRegister(MCP_RXB0CTRL,
             MCP_RXB_RX_MASK | MCP_RXB_BUKT_MASK,
             MCP_RXB_RX_STDEXT | MCP_RXB_BUKT_MASK );
             mcp2515_modifyRegister(MCP_RXB1CTRL, MCP_RXB_RX_MASK,
             MCP_RXB_RX_STDEXT);
             break;
-    
+
             default:
-#if DEBUG_MODE        
+#if DEBUG_MODE
             Serial.print("`Setting ID Mode Failure...\r\n");
-#endif           
+#endif
             return MCP2515_FAIL;
             break;
-}    
+}
 
 
-        res = mcp2515_setCANCTRL_Mode(mcpMode);                                                                
+        res = mcp2515_setCANCTRL_Mode(mcpMode);
         if(res)
         {
-#if DEBUG_MODE        
+#if DEBUG_MODE
           Serial.print("Returning to Previous Mode Failure...\r\n");
-#endif           
+#endif
           return res;
         }
 
@@ -588,7 +592,7 @@ void MCP_CAN::mcp2515_write_id( const INT8U mcp_addr, const INT8U ext, const INT
 
     canid = (uint16_t)(id & 0x0FFFF);
 
-    if ( ext == 1) 
+    if ( ext == 1)
     {
         tbufdata[MCP_EID0] = (INT8U) (canid & 0xFF);
         tbufdata[MCP_EID8] = (INT8U) (canid >> 8);
@@ -598,14 +602,14 @@ void MCP_CAN::mcp2515_write_id( const INT8U mcp_addr, const INT8U ext, const INT
         tbufdata[MCP_SIDL] |= MCP_TXB_EXIDE_M;
         tbufdata[MCP_SIDH] = (INT8U) (canid >> 5 );
     }
-    else 
+    else
     {
         tbufdata[MCP_SIDH] = (INT8U) (canid >> 3 );
         tbufdata[MCP_SIDL] = (INT8U) ((canid & 0x07 ) << 5);
         tbufdata[MCP_EID0] = 0;
         tbufdata[MCP_EID8] = 0;
     }
-    
+
     mcp2515_setRegisterS( mcp_addr, tbufdata, 4 );
 }
 
@@ -620,7 +624,7 @@ void MCP_CAN::mcp2515_write_mf( const INT8U mcp_addr, const INT8U ext, const INT
 
     canid = (uint16_t)(id & 0x0FFFF);
 
-    if ( ext == 1) 
+    if ( ext == 1)
     {
         tbufdata[MCP_EID0] = (INT8U) (canid & 0xFF);
         tbufdata[MCP_EID8] = (INT8U) (canid >> 8);
@@ -630,7 +634,7 @@ void MCP_CAN::mcp2515_write_mf( const INT8U mcp_addr, const INT8U ext, const INT
         tbufdata[MCP_SIDL] |= MCP_TXB_EXIDE_M;
         tbufdata[MCP_SIDH] = (INT8U) (canid >> 5 );
     }
-    else 
+    else
     {
         tbufdata[MCP_EID0] = (INT8U) (canid & 0xFF);
         tbufdata[MCP_EID8] = (INT8U) (canid >> 8);
@@ -638,7 +642,7 @@ void MCP_CAN::mcp2515_write_mf( const INT8U mcp_addr, const INT8U ext, const INT
         tbufdata[MCP_SIDL] = (INT8U) ((canid & 0x07) << 5);
         tbufdata[MCP_SIDH] = (INT8U) (canid >> 3 );
     }
-    
+
     mcp2515_setRegisterS( mcp_addr, tbufdata, 4 );
 }
 
@@ -657,7 +661,7 @@ void MCP_CAN::mcp2515_read_id( const INT8U mcp_addr, INT8U* ext, INT32U* id )
 
     *id = (tbufdata[MCP_SIDH]<<3) + (tbufdata[MCP_SIDL]>>5);
 
-    if ( (tbufdata[MCP_SIDL] & MCP_TXB_EXIDE_M) ==  MCP_TXB_EXIDE_M ) 
+    if ( (tbufdata[MCP_SIDL] & MCP_TXB_EXIDE_M) ==  MCP_TXB_EXIDE_M )
     {
                                                                         /* extended id                  */
         *id = (*id<<2) + (tbufdata[MCP_SIDL] & 0x03);
@@ -676,9 +680,9 @@ void MCP_CAN::mcp2515_write_canMsg( const INT8U buffer_sidh_addr)
     INT8U mcp_addr;
     mcp_addr = buffer_sidh_addr;
     mcp2515_setRegisterS(mcp_addr+5, m_nDta, m_nDlc );                  /* write data bytes             */
-	
+
     if ( m_nRtr == 1)                                                   /* if RTR set bit in byte       */
-        m_nDlc |= MCP_RTR_MASK;  
+        m_nDlc |= MCP_RTR_MASK;
 
     mcp2515_setRegister((mcp_addr+4), m_nDlc );                         /* write the RTR and DLC        */
     mcp2515_write_id(mcp_addr, m_nExtFlg, m_nID );                      /* write CAN id                 */
@@ -695,7 +699,7 @@ void MCP_CAN::mcp2515_read_canMsg( const INT8U buffer_sidh_addr)        /* read 
 
     mcp_addr = buffer_sidh_addr;
 
-    mcp2515_read_id( mcp_addr, &m_nExtFlg,&m_nID );
+    mcp2515_read_id( mcp_addr, &m_nExtFlg, &m_nID );
 
     ctrl = mcp2515_readRegister( mcp_addr-1 );
     m_nDlc = mcp2515_readRegister( mcp_addr+4 );
@@ -726,7 +730,7 @@ INT8U MCP_CAN::mcp2515_getNextFreeTXBuf(INT8U *txbuf_n)                 /* get N
         ctrlval = mcp2515_readRegister( ctrlregs[i] );
         if ( (ctrlval & MCP_TXB_TXREQ_M) == 0 ) {
             *txbuf_n = ctrlregs[i]+1;                                   /* return SIDH-address of Buffer*/
-            
+
             res = MCP2515_OK;
             return res;                                                 /* ! function exit              */
         }
@@ -757,7 +761,7 @@ INT8U MCP_CAN::begin(INT8U idmodeset, INT8U speedset, INT8U clockset)
     res = mcp2515_init(idmodeset, speedset, clockset);
     if (res == MCP2515_OK)
         return CAN_OK;
-    
+
     return CAN_FAILINIT;
 }
 
@@ -774,11 +778,11 @@ INT8U MCP_CAN::init_Mask(INT8U num, INT8U ext, INT32U ulData)
     res = mcp2515_setCANCTRL_Mode(MODE_CONFIG);
     if(res > 0){
 #if DEBUG_MODE
-    Serial.print("Entering Configuration Mode Failure...\r\n"); 
+    Serial.print("Entering Configuration Mode Failure...\r\n");
 #endif
   return res;
 }
-    
+
     if (num == 0){
         mcp2515_write_mf(MCP_RXM0SIDH, ext, ulData);
 
@@ -787,11 +791,11 @@ INT8U MCP_CAN::init_Mask(INT8U num, INT8U ext, INT32U ulData)
         mcp2515_write_mf(MCP_RXM1SIDH, ext, ulData);
     }
     else res =  MCP2515_FAIL;
-    
+
     res = mcp2515_setCANCTRL_Mode(mcpMode);
     if(res > 0){
 #if DEBUG_MODE
-    Serial.print("Entering Previous Mode Failure...\r\nSetting Mask Failure...\r\n"); 
+    Serial.print("Entering Previous Mode Failure...\r\nSetting Mask Failure...\r\n");
 #endif
     return res;
   }
@@ -815,14 +819,14 @@ INT8U MCP_CAN::init_Mask(INT8U num, INT32U ulData)
     res = mcp2515_setCANCTRL_Mode(MODE_CONFIG);
     if(res > 0){
 #if DEBUG_MODE
-    Serial.print("Entering Configuration Mode Failure...\r\n"); 
+    Serial.print("Entering Configuration Mode Failure...\r\n");
 #endif
   return res;
 }
-    
-    if((num & 0x80000000) == 0x80000000)
+
+    if((num & CAN_EXT_HDR_FLAG) == CAN_EXT_HDR_FLAG)
         ext = 1;
-    
+
     if (num == 0){
         mcp2515_write_mf(MCP_RXM0SIDH, ext, ulData);
 
@@ -831,11 +835,11 @@ INT8U MCP_CAN::init_Mask(INT8U num, INT32U ulData)
         mcp2515_write_mf(MCP_RXM1SIDH, ext, ulData);
     }
     else res =  MCP2515_FAIL;
-    
+
     res = mcp2515_setCANCTRL_Mode(mcpMode);
     if(res > 0){
 #if DEBUG_MODE
-    Serial.print("Entering Previous Mode Failure...\r\nSetting Mask Failure...\r\n"); 
+    Serial.print("Entering Previous Mode Failure...\r\nSetting Mask Failure...\r\n");
 #endif
     return res;
   }
@@ -859,11 +863,11 @@ INT8U MCP_CAN::init_Filt(INT8U num, INT8U ext, INT32U ulData)
     if(res > 0)
     {
 #if DEBUG_MODE
-      Serial.print("Enter Configuration Mode Failure...\r\n"); 
+      Serial.print("Enter Configuration Mode Failure...\r\n");
 #endif
       return res;
     }
-    
+
     switch( num )
     {
         case 0:
@@ -893,19 +897,19 @@ INT8U MCP_CAN::init_Filt(INT8U num, INT8U ext, INT32U ulData)
         default:
         res = MCP2515_FAIL;
     }
-    
+
     res = mcp2515_setCANCTRL_Mode(mcpMode);
     if(res > 0)
     {
 #if DEBUG_MODE
-      Serial.print("Entering Previous Mode Failure...\r\nSetting Filter Failure...\r\n"); 
+      Serial.print("Entering Previous Mode Failure...\r\nSetting Filter Failure...\r\n");
 #endif
       return res;
     }
 #if DEBUG_MODE
     Serial.print("Setting Filter Successfull!\r\n");
 #endif
-    
+
     return res;
 }
 
@@ -917,7 +921,7 @@ INT8U MCP_CAN::init_Filt(INT8U num, INT32U ulData)
 {
     INT8U res = MCP2515_OK;
     INT8U ext = 0;
-    
+
 #if DEBUG_MODE
     Serial.print("Starting to Set Filter!\r\n");
 #endif
@@ -925,14 +929,14 @@ INT8U MCP_CAN::init_Filt(INT8U num, INT32U ulData)
     if(res > 0)
     {
 #if DEBUG_MODE
-      Serial.print("Enter Configuration Mode Failure...\r\n"); 
+      Serial.print("Enter Configuration Mode Failure...\r\n");
 #endif
       return res;
     }
-    
-    if((num & 0x80000000) == 0x80000000)
+
+    if((num & CAN_EXT_HDR_FLAG) == CAN_EXT_HDR_FLAG)
         ext = 1;
-    
+
     switch( num )
     {
         case 0:
@@ -962,19 +966,19 @@ INT8U MCP_CAN::init_Filt(INT8U num, INT32U ulData)
         default:
         res = MCP2515_FAIL;
     }
-    
+
     res = mcp2515_setCANCTRL_Mode(mcpMode);
     if(res > 0)
     {
 #if DEBUG_MODE
-      Serial.print("Entering Previous Mode Failure...\r\nSetting Filter Failure...\r\n"); 
+      Serial.print("Entering Previous Mode Failure...\r\nSetting Filter Failure...\r\n");
 #endif
       return res;
     }
 #if DEBUG_MODE
     Serial.print("Setting Filter Successfull!\r\n");
 #endif
-    
+
     return res;
 }
 
@@ -989,9 +993,13 @@ INT8U MCP_CAN::setMsg(INT32U id, INT8U rtr, INT8U ext, INT8U len, INT8U *pData)
     m_nRtr    = rtr;
     m_nExtFlg = ext;
     m_nDlc    = len;
-    for(i = 0; i<MAX_CHAR_IN_MESSAGE; i++)
-        m_nDta[i] = *(pData+i);
-	
+
+	if (m_nDlc > 0)
+	{
+		for (i = 0; i < MAX_CHAR_IN_MESSAGE; i++)
+			m_nDta[i] = *(pData + i);
+	}
+
     return MCP2515_OK;
 }
 
@@ -1026,24 +1034,24 @@ INT8U MCP_CAN::sendMsg()
         uiTimeOut++;
     } while (res == MCP_ALLTXBUSY && (uiTimeOut < TIMEOUTVALUE));
 
-    if(uiTimeOut == TIMEOUTVALUE) 
-    {   
+    if(uiTimeOut == TIMEOUTVALUE)
+    {
         return CAN_GETTXBFTIMEOUT;                                      /* get tx buff time out         */
     }
     uiTimeOut = 0;
     mcp2515_write_canMsg( txbuf_n);
     mcp2515_modifyRegister( txbuf_n-1 , MCP_TXB_TXREQ_M, MCP_TXB_TXREQ_M );
-    
+
     do
     {
-        uiTimeOut++;        
+        uiTimeOut++;
         res1 = mcp2515_readRegister(txbuf_n-1);                         /* read send buff ctrl reg 	*/
-        res1 = res1 & 0x08;                               		
-    } while (res1 && (uiTimeOut < TIMEOUTVALUE));   
-    
-    if(uiTimeOut == TIMEOUTVALUE)                                       /* send msg timeout             */	
+        res1 = res1 & 0x08;
+    } while (res1 && (uiTimeOut < TIMEOUTVALUE));
+
+    if(uiTimeOut == TIMEOUTVALUE)                                       /* send msg timeout             */
         return CAN_SENDMSGTIMEOUT;
-    
+
     return CAN_OK;
 }
 
@@ -1054,10 +1062,10 @@ INT8U MCP_CAN::sendMsg()
 INT8U MCP_CAN::sendMsgBuf(INT32U id, INT8U ext, INT8U len, INT8U *buf)
 {
     INT8U res;
-	
+
     setMsg(id, 0, ext, len, buf);
     res = sendMsg();
-    
+
     return res;
 }
 
@@ -1069,16 +1077,16 @@ INT8U MCP_CAN::sendMsgBuf(INT32U id, INT8U len, INT8U *buf)
 {
     INT8U ext = 0, rtr = 0;
     INT8U res;
-    
-    if((id & 0x80000000) == 0x80000000)
+
+    if((id & CAN_EXT_HDR_FLAG) == CAN_EXT_HDR_FLAG)
         ext = 1;
- 
-    if((id & 0x40000000) == 0x40000000)
+
+    if((id & CAN_RTR_FLAG) == CAN_RTR_FLAG)
         rtr = 1;
-        
+
     setMsg(id, rtr, ext, len, buf);
     res = sendMsg();
-    
+
     return res;
 }
 
@@ -1104,9 +1112,9 @@ INT8U MCP_CAN::readMsg()
         mcp2515_modifyRegister(MCP_CANINTF, MCP_RX1IF, 0);
         res = CAN_OK;
     }
-    else 
+    else
         res = CAN_NOMSG;
-    
+
     return res;
 }
 
@@ -1118,12 +1126,16 @@ INT8U MCP_CAN::readMsgBuf(INT32U *id, INT8U *ext, INT8U *len, INT8U buf[])
 {
     if(readMsg() == CAN_NOMSG)
 	return CAN_NOMSG;
-	
+
     *id  = m_nID;
     *len = m_nDlc;
     *ext = m_nExtFlg;
-    for(int i = 0; i<m_nDlc; i++)
-        buf[i] = m_nDta[i];
+
+	if (m_nDlc > 0)
+	{
+		for (int i = 0; i < m_nDlc; i++)
+			buf[i] = m_nDta[i];
+	}
 
     return CAN_OK;
 }
@@ -1138,16 +1150,19 @@ INT8U MCP_CAN::readMsgBuf(INT32U *id, INT8U *len, INT8U buf[])
 	return CAN_NOMSG;
 
     if (m_nExtFlg)
-        m_nID |= 0x80000000;
+        m_nID |= CAN_EXT_HDR_FLAG;
 
     if (m_nRtr)
-        m_nID |= 0x40000000;
-	
+        m_nID |= CAN_RTR_FLAG;
+
     *id  = m_nID;
     *len = m_nDlc;
-    
-    for(int i = 0; i<m_nDlc; i++)
-        buf[i] = m_nDta[i];
+
+	if (m_nDlc > 0)
+	{
+		for (int i = 0; i < m_nDlc; i++)
+			buf[i] = m_nDta[i];
+	}
 
     return CAN_OK;
 }
@@ -1162,7 +1177,7 @@ INT8U MCP_CAN::checkReceive(void)
     res = mcp2515_readStatus();                                         /* RXnIF in Bit 1 and 0         */
     if ( res & MCP_STAT_RXIF_MASK )
         return CAN_MSGAVAIL;
-    else 
+    else
         return CAN_NOMSG;
 }
 
@@ -1174,7 +1189,7 @@ INT8U MCP_CAN::checkError(void)
 {
     INT8U eflg = mcp2515_readRegister(MCP_EFLG);
 
-    if ( eflg & MCP_EFLG_ERRORMASK ) 
+    if ( eflg & MCP_EFLG_ERRORMASK )
         return CAN_CTRLERROR;
     else
         return CAN_OK;
@@ -1193,7 +1208,7 @@ INT8U MCP_CAN::getError(void)
 ** Function name:           mcp2515_errorCountRX
 ** Descriptions:            Returns REC register value
 *********************************************************************************************************/
-INT8U MCP_CAN::errorCountRX(void)                             
+INT8U MCP_CAN::errorCountRX(void)
 {
     return mcp2515_readRegister(MCP_REC);
 }
@@ -1202,7 +1217,7 @@ INT8U MCP_CAN::errorCountRX(void)
 ** Function name:           mcp2515_errorCountTX
 ** Descriptions:            Returns TEC register value
 *********************************************************************************************************/
-INT8U MCP_CAN::errorCountTX(void)                             
+INT8U MCP_CAN::errorCountTX(void)
 {
     return mcp2515_readRegister(MCP_TEC);
 }
@@ -1211,7 +1226,7 @@ INT8U MCP_CAN::errorCountTX(void)
 ** Function name:           mcp2515_enOneShotTX
 ** Descriptions:            Enables one shot transmission mode
 *********************************************************************************************************/
-INT8U MCP_CAN::enOneShotTX(void)                             
+INT8U MCP_CAN::enOneShotTX(void)
 {
     mcp2515_modifyRegister(MCP_CANCTRL, MODE_ONESHOT, MODE_ONESHOT);
     if((mcp2515_readRegister(MCP_CANCTRL) & MODE_ONESHOT) != MODE_ONESHOT)
@@ -1224,7 +1239,7 @@ INT8U MCP_CAN::enOneShotTX(void)
 ** Function name:           mcp2515_disOneShotTX
 ** Descriptions:            Disables one shot transmission mode
 *********************************************************************************************************/
-INT8U MCP_CAN::disOneShotTX(void)                             
+INT8U MCP_CAN::disOneShotTX(void)
 {
     mcp2515_modifyRegister(MCP_CANCTRL, MODE_ONESHOT, 0);
     if((mcp2515_readRegister(MCP_CANCTRL) & MODE_ONESHOT) != 0)

--- a/mcp_can_dfs.h
+++ b/mcp_can_dfs.h
@@ -462,6 +462,9 @@
 
 #define CAN_MAX_CHAR_IN_MESSAGE (8)
 
+#define CAN_RTR_FLAG     0x40000000
+#define CAN_EXT_HDR_FLAG 0x80000000
+
 #endif
 /*********************************************************************************************************
   END FILE


### PR DESCRIPTION
This version has been modified to allow for zero-length (viz. header-only) CAN messages.
These are used with the RTR bit set when querying a CAN network for the CAN_IDs of other modules.