### PR TITLE
Add function for reading message with rtr field as a function argument

### DIFF
--- a/mcp_can.cpp
+++ b/mcp_can.cpp
@@ -1130,6 +1130,25 @@ INT8U MCP_CAN::readMsg()
 ** Function name:           readMsgBuf
 ** Descriptions:            Public function, Reads message from receive buffer.
 *********************************************************************************************************/
+INT8U MCP_CAN::readMsgBuf(INT32U *id, INT8U *ext, INT8U *rtr, INT8U *len, INT8U buf[])
+{
+    if(readMsg() == CAN_NOMSG)
+	return CAN_NOMSG;
+	
+    *id  = m_nID;
+    *len = m_nDlc;
+    *ext = m_nExtFlg;
+    *rtr = m_nRtr;
+    for(int i = 0; i<m_nDlc; i++)
+        buf[i] = m_nDta[i];
+
+    return CAN_OK;
+}
+
+/*********************************************************************************************************
+** Function name:           readMsgBuf
+** Descriptions:            Public function, Reads message from receive buffer.
+*********************************************************************************************************/
 INT8U MCP_CAN::readMsgBuf(INT32U *id, INT8U *ext, INT8U *len, INT8U buf[])
 {
     if(readMsg() == CAN_NOMSG)

--- a/mcp_can.h
+++ b/mcp_can.h
@@ -113,6 +113,7 @@ public:
     INT8U setMode(INT8U opMode);                                        // Set operational mode
     INT8U sendMsgBuf(INT32U id, INT8U ext, INT8U len, INT8U *buf);      // Send message to transmit buffer
     INT8U sendMsgBuf(INT32U id, INT8U len, INT8U *buf);                 // Send message to transmit buffer
+    INT8U readMsgBuf(INT32U *id, INT8U *ext, INT8U * rtr, INT8U *len, INT8U *buf);   // Read message from receive buffer
     INT8U readMsgBuf(INT32U *id, INT8U *ext, INT8U *len, INT8U *buf);   // Read message from receive buffer
     INT8U readMsgBuf(INT32U *id, INT8U *len, INT8U *buf);               // Read message from receive buffer
     INT8U checkReceive(void);                                           // Check for received data


### PR DESCRIPTION
By this time obtaining `rtr` from message was possible only by calling `readMsgBuf` which combines `ext` and `rtr` flags in `id`.
This one make it easier (and more readable than [this](https://github.com/coryjfowler/MCP_CAN_lib/blob/0fb5064690b643c07f34eeae8b10d35f22f29dd7/examples/CAN_receive/CAN_receive.ino#L46))