### PR TITLE
Created new function to directly write to TX0 Buffer.

### DIFF
--- a/mcp_can.cpp
+++ b/mcp_can.cpp
@@ -1296,7 +1296,7 @@ void MCP_CAN::setupTX0Buf(INT32U id, INT8U len, INT8U *buf)
   INT8U tbufdata[4];
   canid = (uint16_t)(id & 0x0FFFF);
   
-  SPI.beginTransaction(SPISettings(10000000, MSBFIRST, SPI_MODE0));
+  SPI.beginTransaction(SPISettings(8000000, MSBFIRST, SPI_MODE0));
   // LOAD TX BUFFER 0
   MCP2515_SELECT();
   spi_readwrite(MCP_LOAD_TX0);
@@ -1323,7 +1323,7 @@ void MCP_CAN::setupTX0Buf(INT32U id, INT8U len, INT8U *buf)
   }
   MCP2515_UNSELECT();
   SPI.endTransaction();
-  delayMicroseconds(100);
+  delayMicroseconds(150);
 }
 
 /*********************************************************************************************************
@@ -1333,7 +1333,7 @@ void MCP_CAN::setupTX0Buf(INT32U id, INT8U len, INT8U *buf)
 INT8U MCP_CAN::tx0RTS()
 {
   // READY TO SEND
-  SPI.beginTransaction(SPISettings(10000000, MSBFIRST, SPI_MODE0));
+  SPI.beginTransaction(SPISettings(8000000, MSBFIRST, SPI_MODE0));
   MCP2515_SELECT();
   spi_readwrite(MCP_RTS_TX0);
   MCP2515_UNSELECT();

--- a/mcp_can.cpp
+++ b/mcp_can.cpp
@@ -37,7 +37,7 @@ void MCP_CAN::mcp2515_reset(void)
     spi_readwrite(MCP_RESET);
     MCP2515_UNSELECT();
     SPI.endTransaction();
-    delayMicroseconds(10);
+    delayMicroseconds(100);
 }
 
 /*********************************************************************************************************
@@ -107,7 +107,7 @@ void MCP_CAN::mcp2515_setRegisterS(const INT8U address, const INT8U values[], co
        
     for (i=0; i<n; i++) 
         spi_readwrite(values[i]);
-	
+  
     MCP2515_UNSELECT();
     SPI.endTransaction();
 }
@@ -272,7 +272,7 @@ INT8U MCP_CAN::mcp2515_configRate(const INT8U canSpeed, const INT8U canClock)
 
             default:
             set = 0;
-	    return MCP2515_FAIL;
+      return MCP2515_FAIL;
             break;
         }
         break;
@@ -359,7 +359,7 @@ INT8U MCP_CAN::mcp2515_configRate(const INT8U canSpeed, const INT8U canClock)
 
             default:
             set = 0;
-	    return MCP2515_FAIL;
+      return MCP2515_FAIL;
             break;
         }
         break;
@@ -430,7 +430,7 @@ INT8U MCP_CAN::mcp2515_configRate(const INT8U canSpeed, const INT8U canClock)
         
         default:
         set = 0;
-	return MCP2515_FAIL;
+  return MCP2515_FAIL;
         break;
     }
 
@@ -457,14 +457,14 @@ void MCP_CAN::mcp2515_initCANBuffers(void)
     INT32U ulMask = 0x00, ulFilt = 0x00;
 
 
-    mcp2515_write_mf(MCP_RXM0SIDH, ext, ulMask);			/*Set both masks to 0           */
-    mcp2515_write_mf(MCP_RXM1SIDH, ext, ulMask);			/*Mask register ignores ext bit */
+    mcp2515_write_mf(MCP_RXM0SIDH, ext, ulMask);      /*Set both masks to 0           */
+    mcp2515_write_mf(MCP_RXM1SIDH, ext, ulMask);      /*Mask register ignores ext bit */
     
                                                                         /* Set all filters to 0         */
-    mcp2515_write_mf(MCP_RXF0SIDH, ext, ulFilt);			/* RXB0: extended               */
-    mcp2515_write_mf(MCP_RXF1SIDH, std, ulFilt);			/* RXB1: standard               */
-    mcp2515_write_mf(MCP_RXF2SIDH, ext, ulFilt);			/* RXB2: extended               */
-    mcp2515_write_mf(MCP_RXF3SIDH, std, ulFilt);			/* RXB3: standard               */
+    mcp2515_write_mf(MCP_RXF0SIDH, ext, ulFilt);      /* RXB0: extended               */
+    mcp2515_write_mf(MCP_RXF1SIDH, std, ulFilt);      /* RXB1: standard               */
+    mcp2515_write_mf(MCP_RXF2SIDH, ext, ulFilt);      /* RXB2: extended               */
+    mcp2515_write_mf(MCP_RXF3SIDH, std, ulFilt);      /* RXB3: standard               */
     mcp2515_write_mf(MCP_RXF4SIDH, ext, ulFilt);
     mcp2515_write_mf(MCP_RXF5SIDH, std, ulFilt);
 
@@ -531,10 +531,10 @@ INT8U MCP_CAN::mcp2515_init(const INT8U canIDMode, const INT8U canSpeed, const I
                                                                         /* interrupt mode               */
         mcp2515_setRegister(MCP_CANINTE, MCP_RX0IF | MCP_RX1IF);
 
-	//Sets BF pins as GPO
-	mcp2515_setRegister(MCP_BFPCTRL,MCP_BxBFS_MASK | MCP_BxBFE_MASK);
-	//Sets RTS pins as GPI
-	mcp2515_setRegister(MCP_TXRTSCTRL,0x00);
+  //Sets BF pins as GPO
+  mcp2515_setRegister(MCP_BFPCTRL,MCP_BxBFS_MASK | MCP_BxBFE_MASK);
+  //Sets RTS pins as GPI
+  mcp2515_setRegister(MCP_TXRTSCTRL,0x00);
 
         switch(canIDMode)
         {
@@ -692,7 +692,7 @@ void MCP_CAN::mcp2515_write_canMsg( const INT8U buffer_sidh_addr)
     INT8U mcp_addr;
     mcp_addr = buffer_sidh_addr;
     mcp2515_setRegisterS(mcp_addr+5, m_nDta, m_nDlc );                  /* write data bytes             */
-	
+  
     if ( m_nRtr == 1)                                                   /* if RTR set bit in byte       */
         m_nDlc |= MCP_RTR_MASK;  
 
@@ -790,9 +790,9 @@ INT8U MCP_CAN::init_Mask(INT8U num, INT8U ext, INT32U ulData)
     res = mcp2515_setCANCTRL_Mode(MODE_CONFIG);
     if(res > 0){
 #if DEBUG_MODE
-	Serial.print("Entering Configuration Mode Failure...\r\n"); 
+  Serial.print("Entering Configuration Mode Failure...\r\n"); 
 #endif
-	return res;
+  return res;
      }
     
     if (num == 0){
@@ -807,9 +807,9 @@ INT8U MCP_CAN::init_Mask(INT8U num, INT8U ext, INT32U ulData)
     res = mcp2515_setCANCTRL_Mode(mcpMode);
     if(res > 0){
 #if DEBUG_MODE
-	Serial.print("Entering Previous Mode Failure...\r\nSetting Mask Failure...\r\n"); 
+  Serial.print("Entering Previous Mode Failure...\r\nSetting Mask Failure...\r\n"); 
 #endif
-	return res;
+  return res;
     }
 #if DEBUG_MODE
     Serial.print("Setting Mask Successful!\r\n");
@@ -1007,7 +1007,7 @@ INT8U MCP_CAN::setMsg(INT32U id, INT8U rtr, INT8U ext, INT8U len, INT8U *pData)
     m_nDlc    = len;
     for(i = 0; i<MAX_CHAR_IN_MESSAGE; i++)
         m_nDta[i] = *(pData+i);
-	
+  
     return MCP2515_OK;
 }
 
@@ -1053,11 +1053,11 @@ INT8U MCP_CAN::sendMsg()
     do
     {
         uiTimeOut++;        
-        res1 = mcp2515_readRegister(txbuf_n-1);                         /* read send buff ctrl reg 	*/
-        res1 = res1 & 0x08;                               		
+        res1 = mcp2515_readRegister(txbuf_n-1);                         /* read send buff ctrl reg  */
+        res1 = res1 & 0x08;                                   
     } while (res1 && (uiTimeOut < TIMEOUTVALUE));   
     
-    if(uiTimeOut == TIMEOUTVALUE)                                       /* send msg timeout             */	
+    if(uiTimeOut == TIMEOUTVALUE)                                       /* send msg timeout             */  
         return CAN_SENDMSGTIMEOUT;
     
     return CAN_OK;
@@ -1070,7 +1070,7 @@ INT8U MCP_CAN::sendMsg()
 INT8U MCP_CAN::sendMsgBuf(INT32U id, INT8U ext, INT8U len, INT8U *buf)
 {
     INT8U res;
-	
+  
     setMsg(id, 0, ext, len, buf);
     res = sendMsg();
     
@@ -1133,8 +1133,8 @@ INT8U MCP_CAN::readMsg()
 INT8U MCP_CAN::readMsgBuf(INT32U *id, INT8U *ext, INT8U *len, INT8U buf[])
 {
     if(readMsg() == CAN_NOMSG)
-	return CAN_NOMSG;
-	
+  return CAN_NOMSG;
+  
     *id  = m_nID;
     *len = m_nDlc;
     *ext = m_nExtFlg;
@@ -1151,14 +1151,14 @@ INT8U MCP_CAN::readMsgBuf(INT32U *id, INT8U *ext, INT8U *len, INT8U buf[])
 INT8U MCP_CAN::readMsgBuf(INT32U *id, INT8U *len, INT8U buf[])
 {
     if(readMsg() == CAN_NOMSG)
-	return CAN_NOMSG;
+  return CAN_NOMSG;
 
     if (m_nExtFlg)
         m_nID |= 0x80000000;
 
     if (m_nRtr)
         m_nID |= 0x40000000;
-	
+  
     *id  = m_nID;
     *len = m_nDlc;
     
@@ -1231,9 +1231,9 @@ INT8U MCP_CAN::enOneShotTX(void)
 {
     mcp2515_modifyRegister(MCP_CANCTRL, MODE_ONESHOT, MODE_ONESHOT);
     if((mcp2515_readRegister(MCP_CANCTRL) & MODE_ONESHOT) != MODE_ONESHOT)
-	    return CAN_FAIL;
+      return CAN_FAIL;
     else
-	    return CAN_OK;
+      return CAN_OK;
 }
 
 /*********************************************************************************************************
@@ -1256,12 +1256,12 @@ INT8U MCP_CAN::disOneShotTX(void)
 INT8U MCP_CAN::abortTX(void)                             
 {
     mcp2515_modifyRegister(MCP_CANCTRL, ABORT_TX, ABORT_TX);
-	
+  
     // Maybe check to see if the TX buffer transmission request bits are cleared instead?
     if((mcp2515_readRegister(MCP_CANCTRL) & ABORT_TX) != ABORT_TX)
-	    return CAN_FAIL;
+      return CAN_FAIL;
     else
-	    return CAN_OK;
+      return CAN_OK;
 }
 
 /*********************************************************************************************************
@@ -1271,7 +1271,7 @@ INT8U MCP_CAN::abortTX(void)
 INT8U MCP_CAN::setGPO(INT8U data)
 {
     mcp2515_modifyRegister(MCP_BFPCTRL, MCP_BxBFS_MASK, (data<<4));
-	    
+      
     return 0;
 }
 
@@ -1361,6 +1361,7 @@ INT8U MCP_CAN::sendTX0(INT32U id, INT8U len, INT8U *buf)
   INT8U res;
   setupTX0Buf(id,len,buf);
   res = tx0RTS();
+  return res;
 }
 
 /*********************************************************************************************************

--- a/mcp_can.cpp
+++ b/mcp_can.cpp
@@ -37,7 +37,7 @@ void MCP_CAN::mcp2515_reset(void)
     spi_readwrite(MCP_RESET);
     MCP2515_UNSELECT();
     SPI.endTransaction();
-    delayMicroseconds(100);
+    delayMicroseconds(10);
 }
 
 /*********************************************************************************************************
@@ -1323,7 +1323,8 @@ void MCP_CAN::setupTX0Buf(INT32U id, INT8U len, INT8U *buf)
   }
   MCP2515_UNSELECT();
   SPI.endTransaction();
-  delayMicroseconds(250);}
+  delayMicroseconds(100);
+}
 
 /*********************************************************************************************************
 ** Function name:           tx0RTS

--- a/mcp_can.h
+++ b/mcp_can.h
@@ -93,7 +93,7 @@ class MCP_CAN
     void mcp2515_write_canMsg( const INT8U buffer_sidh_addr );          // Write CAN message
     void mcp2515_read_canMsg( const INT8U buffer_sidh_addr);            // Read CAN message
     INT8U mcp2515_getNextFreeTXBuf(INT8U *txbuf_n);                     // Find empty transmit buffer
-    void setupTX0Buf(INT32U id, INT8U len, INT8U *buf);                 // Set TX0 buffer directly
+    void setupTX0Buf(INT32U id, INT8U len, INT8U *buf, bool fastMode);  // Set TX0 buffer directly
     INT8U tx0RTS();                                                     // Set register to send TX0 buffer
 
 /*********************************************************************************************************
@@ -127,7 +127,7 @@ public:
     INT8U abortTX(void);                                                // Abort queued transmission(s)
     INT8U setGPO(INT8U data);                                           // Sets GPO
     INT8U getGPI(void);                                                 // Reads GPI
-    INT8U sendTX0(INT32U id, INT8U len, INT8U *buf);                    // Sends message directly using TX0
+    INT8U sendTX0(INT32U id, INT8U len, INT8U *buf, bool fastMode);     // Sends message directly using TX0
 };
 
 #endif

--- a/mcp_can.h
+++ b/mcp_can.h
@@ -93,6 +93,8 @@ class MCP_CAN
     void mcp2515_write_canMsg( const INT8U buffer_sidh_addr );          // Write CAN message
     void mcp2515_read_canMsg( const INT8U buffer_sidh_addr);            // Read CAN message
     INT8U mcp2515_getNextFreeTXBuf(INT8U *txbuf_n);                     // Find empty transmit buffer
+    void setupTX0Buf(INT32U id, INT8U len, INT8U *buf);                 // Set TX0 buffer directly
+    INT8U tx0RTS();                                                     // Set register to send TX0 buffer
 
 /*********************************************************************************************************
  *  CAN operator function
@@ -125,6 +127,7 @@ public:
     INT8U abortTX(void);                                                // Abort queued transmission(s)
     INT8U setGPO(INT8U data);                                           // Sets GPO
     INT8U getGPI(void);                                                 // Reads GPI
+    INT8U sendTX0(INT32U id, INT8U len, INT8U *buf);                    // Sends message directly using TX0
 };
 
 #endif


### PR DESCRIPTION
Added the following to increase the CAN message throughput.
Arduino nano using sendMsgBuf(canid, 1, len, data) and 8 byte messages max msgs/s 866
Arduino nano using senTX0(canid, len, data) and 8 byte messages max msgs/s 1737
setupTX0Buf uses shorter instruction to put the CAN message into the TX0 buffer
tx0RTS uses a single instruction to send the CAN message in TX0 buffer
sendTX0 works in the same way as sendMsgBuf