### PR TITLE
Guard debug mode definition

### DIFF
--- a/mcp_can_dfs.h
+++ b/mcp_can_dfs.h
@@ -37,7 +37,9 @@
 #endif
 
 // if print debug information
+#ifndef DEBUG_MODE
 #define DEBUG_MODE 1
+#endif
 
 /*
  *   Begin mt


### PR DESCRIPTION
Guard DEBUG_MODE to allow control from the main program.