### PR TITLE
Set DEBUG_MODE to 0 by default

### DIFF
--- a/mcp_can_dfs.h
+++ b/mcp_can_dfs.h
@@ -37,7 +37,7 @@
 #endif
 
 // if print debug information
-#define DEBUG_MODE 1
+#define DEBUG_MODE 0
 
 /*
  *   Begin mt


### PR DESCRIPTION
Having DEBUG_MODE set to 1 makes the library write to default serial, which can be unexpected if it's already used for other communication. This PR simply sets DEBUG_MODE define to 0.