### PR TITLE
Allow clkout to be selected in CNF3 register.

### DIFF
--- a/mcp_can.cpp
+++ b/mcp_can.cpp
@@ -233,7 +233,7 @@ INT8U MCP_CAN::mcp2515_configRate(const INT8U canSpeed, const INT8U canClock)
 {
     INT8U set, cfg1, cfg2, cfg3;
     set = 1;
-    switch (canClock)
+    switch (canClock & MCP_CLOCK_SELECT)
     {
         case (MCP_8MHZ):
         switch (canSpeed) 
@@ -484,6 +484,10 @@ INT8U MCP_CAN::mcp2515_configRate(const INT8U canSpeed, const INT8U canClock)
         set = 0;
 	return MCP2515_FAIL;
         break;
+    }
+
+    if (canClock & MCP_CLKOUT_ENABLE) {
+        cfg3 &= (~SOF_ENABLE);
     }
 
     if (set) {

--- a/mcp_can_dfs.h
+++ b/mcp_can_dfs.h
@@ -441,6 +441,9 @@
 #define MCP_20MHZ    0
 #define MCP_16MHZ    1
 #define MCP_8MHZ     2
+#define MCP_CLOCK_SELECT 3
+#define MCP_CLKOUT_ENABLE 4
+
 
 #define CAN_4K096BPS 0
 #define CAN_5KBPS    1


### PR DESCRIPTION
Clkout is enabled by default and switched to SOF in all cases. This small change allows the user to select the CLKOUT pin by calling the initiator like this: `CAN0.begin(MCP_STDEXT, CAN_500KBPS, MCP_8MHZ | MCP_CLKOUT_ENABLE)`