### PR TITLE
SPI-Bus selectable in constructor

### DIFF
--- a/mcp_can.cpp
+++ b/mcp_can.cpp
@@ -23,7 +23,7 @@
 */
 #include "mcp_can.h"
 
-#define spi_readwrite SPI.transfer
+#define spi_readwrite SPI->transfer
 #define spi_read() spi_readwrite(0x00)
 
 /*********************************************************************************************************
@@ -32,11 +32,11 @@
 *********************************************************************************************************/
 void MCP_CAN::mcp2515_reset(void)                                      
 {
-    SPI.beginTransaction(SPISettings(10000000, MSBFIRST, SPI_MODE0));
+    SPI->beginTransaction(SPISettings(10000000, MSBFIRST, SPI_MODE0));
     MCP2515_SELECT();
     spi_readwrite(MCP_RESET);
     MCP2515_UNSELECT();
-    SPI.endTransaction();
+    SPI->endTransaction();
     delay(5); // If the MCP2515 was in sleep mode when the reset command was issued then we need to wait a while for it to reset properly
 }
 
@@ -48,13 +48,13 @@ INT8U MCP_CAN::mcp2515_readRegister(const INT8U address)
 {
     INT8U ret;
 
-    SPI.beginTransaction(SPISettings(10000000, MSBFIRST, SPI_MODE0));
+    SPI->beginTransaction(SPISettings(10000000, MSBFIRST, SPI_MODE0));
     MCP2515_SELECT();
     spi_readwrite(MCP_READ);
     spi_readwrite(address);
     ret = spi_read();
     MCP2515_UNSELECT();
-    SPI.endTransaction();
+    SPI->endTransaction();
 
     return ret;
 }
@@ -66,7 +66,7 @@ INT8U MCP_CAN::mcp2515_readRegister(const INT8U address)
 void MCP_CAN::mcp2515_readRegisterS(const INT8U address, INT8U values[], const INT8U n)
 {
     INT8U i;
-    SPI.beginTransaction(SPISettings(10000000, MSBFIRST, SPI_MODE0));
+    SPI->beginTransaction(SPISettings(10000000, MSBFIRST, SPI_MODE0));
     MCP2515_SELECT();
     spi_readwrite(MCP_READ);
     spi_readwrite(address);
@@ -75,7 +75,7 @@ void MCP_CAN::mcp2515_readRegisterS(const INT8U address, INT8U values[], const I
         values[i] = spi_read();
 
     MCP2515_UNSELECT();
-    SPI.endTransaction();
+    SPI->endTransaction();
 }
 
 /*********************************************************************************************************
@@ -84,13 +84,13 @@ void MCP_CAN::mcp2515_readRegisterS(const INT8U address, INT8U values[], const I
 *********************************************************************************************************/
 void MCP_CAN::mcp2515_setRegister(const INT8U address, const INT8U value)
 {
-    SPI.beginTransaction(SPISettings(10000000, MSBFIRST, SPI_MODE0));
+    SPI->beginTransaction(SPISettings(10000000, MSBFIRST, SPI_MODE0));
     MCP2515_SELECT();
     spi_readwrite(MCP_WRITE);
     spi_readwrite(address);
     spi_readwrite(value);
     MCP2515_UNSELECT();
-    SPI.endTransaction();
+    SPI->endTransaction();
 }
 
 /*********************************************************************************************************
@@ -100,7 +100,7 @@ void MCP_CAN::mcp2515_setRegister(const INT8U address, const INT8U value)
 void MCP_CAN::mcp2515_setRegisterS(const INT8U address, const INT8U values[], const INT8U n)
 {
     INT8U i;
-    SPI.beginTransaction(SPISettings(10000000, MSBFIRST, SPI_MODE0));
+    SPI->beginTransaction(SPISettings(10000000, MSBFIRST, SPI_MODE0));
     MCP2515_SELECT();
     spi_readwrite(MCP_WRITE);
     spi_readwrite(address);
@@ -109,7 +109,7 @@ void MCP_CAN::mcp2515_setRegisterS(const INT8U address, const INT8U values[], co
         spi_readwrite(values[i]);
 	
     MCP2515_UNSELECT();
-    SPI.endTransaction();
+    SPI->endTransaction();
 }
 
 /*********************************************************************************************************
@@ -118,14 +118,14 @@ void MCP_CAN::mcp2515_setRegisterS(const INT8U address, const INT8U values[], co
 *********************************************************************************************************/
 void MCP_CAN::mcp2515_modifyRegister(const INT8U address, const INT8U mask, const INT8U data)
 {
-    SPI.beginTransaction(SPISettings(10000000, MSBFIRST, SPI_MODE0));
+    SPI->beginTransaction(SPISettings(10000000, MSBFIRST, SPI_MODE0));
     MCP2515_SELECT();
     spi_readwrite(MCP_BITMOD);
     spi_readwrite(address);
     spi_readwrite(mask);
     spi_readwrite(data);
     MCP2515_UNSELECT();
-    SPI.endTransaction();
+    SPI->endTransaction();
 }
 
 /*********************************************************************************************************
@@ -135,12 +135,12 @@ void MCP_CAN::mcp2515_modifyRegister(const INT8U address, const INT8U mask, cons
 INT8U MCP_CAN::mcp2515_readStatus(void)                             
 {
     INT8U i;
-    SPI.beginTransaction(SPISettings(10000000, MSBFIRST, SPI_MODE0));
+    SPI->beginTransaction(SPISettings(10000000, MSBFIRST, SPI_MODE0));
     MCP2515_SELECT();
     spi_readwrite(MCP_READ_STATUS);
     i = spi_read();
     MCP2515_UNSELECT();
-    SPI.endTransaction();
+    SPI->endTransaction();
     return i;
 }
 
@@ -815,6 +815,19 @@ MCP_CAN::MCP_CAN(INT8U _CS)
     MCPCS = _CS;
     MCP2515_UNSELECT();
     pinMode(MCPCS, OUTPUT);
+    SPI = SPI;
+}
+
+/*********************************************************************************************************
+** Function name:           MCP_CAN
+** Descriptions:            Public function to declare CAN class with SPI and the /CS pin.
+*********************************************************************************************************/
+MCP_CAN::MCP_CAN(SPIClass *_SPI, INT8U _CS)
+{
+    MCPCS = _CS;
+    MCP2515_UNSELECT();
+    pinMode(MCPCS, OUTPUT);
+    SPI = _SPI;
 }
 
 /*********************************************************************************************************
@@ -825,7 +838,7 @@ INT8U MCP_CAN::begin(INT8U idmodeset, INT8U speedset, INT8U clockset)
 {
     INT8U res;
 
-    SPI.begin();
+    SPI->begin();
     res = mcp2515_init(idmodeset, speedset, clockset);
     if (res == MCP2515_OK)
         return CAN_OK;
@@ -1095,16 +1108,14 @@ INT8U MCP_CAN::clearMsg()
 INT8U MCP_CAN::sendMsg()
 {
     INT8U res, res1, txbuf_n;
-    uint32_t uiTimeOut, temp;
+    uint16_t uiTimeOut = 0;
 
-    temp = micros();
-    // 24 * 4 microseconds typical
     do {
         res = mcp2515_getNextFreeTXBuf(&txbuf_n);                       /* info = addr.                 */
-        uiTimeOut = micros() - temp;
+        uiTimeOut++;
     } while (res == MCP_ALLTXBUSY && (uiTimeOut < TIMEOUTVALUE));
 
-    if(uiTimeOut >= TIMEOUTVALUE) 
+    if(uiTimeOut == TIMEOUTVALUE) 
     {   
         return CAN_GETTXBFTIMEOUT;                                      /* get tx buff time out         */
     }
@@ -1112,15 +1123,14 @@ INT8U MCP_CAN::sendMsg()
     mcp2515_write_canMsg( txbuf_n);
     mcp2515_modifyRegister( txbuf_n-1 , MCP_TXB_TXREQ_M, MCP_TXB_TXREQ_M );
     
-    temp = micros();
     do
-    {        
+    {
+        uiTimeOut++;        
         res1 = mcp2515_readRegister(txbuf_n-1);                         /* read send buff ctrl reg 	*/
         res1 = res1 & 0x08;                               		
-        uiTimeOut = micros() - temp;
     } while (res1 && (uiTimeOut < TIMEOUTVALUE));   
     
-    if(uiTimeOut >= TIMEOUTVALUE)                                       /* send msg timeout             */	
+    if(uiTimeOut == TIMEOUTVALUE)                                       /* send msg timeout             */	
         return CAN_SENDMSGTIMEOUT;
     
     return CAN_OK;

--- a/mcp_can.cpp
+++ b/mcp_can.cpp
@@ -1109,7 +1109,7 @@ INT8U MCP_CAN::sendMsg()
 {
     INT8U res, res1, txbuf_n;
     uint32_t uiTimeOut, temp;
-	
+
     temp = micros();
     // 24 * 4 microseconds typical
     do {
@@ -1121,7 +1121,7 @@ INT8U MCP_CAN::sendMsg()
     {   
         return CAN_GETTXBFTIMEOUT;                                      /* get tx buff time out         */
     }
-    uiTimeOut = micros;
+    uiTimeOut = 0;
     mcp2515_write_canMsg( txbuf_n);
     mcp2515_modifyRegister( txbuf_n-1 , MCP_TXB_TXREQ_M, MCP_TXB_TXREQ_M );
     
@@ -1130,7 +1130,7 @@ INT8U MCP_CAN::sendMsg()
     {       
         res1 = mcp2515_readRegister(txbuf_n-1);                         /* read send buff ctrl reg 	*/
         res1 = res1 & 0x08;
-	uiTimeOut = micros() - temp;
+        uiTimeOut = micros() - temp;
     } while (res1 && (uiTimeOut < TIMEOUTVALUE));   
     
     if(uiTimeOut >= TIMEOUTVALUE)                                       /* send msg timeout             */	

--- a/mcp_can.cpp
+++ b/mcp_can.cpp
@@ -1108,29 +1108,32 @@ INT8U MCP_CAN::clearMsg()
 INT8U MCP_CAN::sendMsg()
 {
     INT8U res, res1, txbuf_n;
-    uint16_t uiTimeOut = 0;
-
+    uint32_t uiTimeOut, temp;
+	
+    temp = micros();
+    // 24 * 4 microseconds typical
     do {
         res = mcp2515_getNextFreeTXBuf(&txbuf_n);                       /* info = addr.                 */
-        uiTimeOut++;
+        uiTimeOut = micros() - temp;
     } while (res == MCP_ALLTXBUSY && (uiTimeOut < TIMEOUTVALUE));
 
-    if(uiTimeOut == TIMEOUTVALUE) 
+    if(uiTimeOut >= TIMEOUTVALUE) 
     {   
         return CAN_GETTXBFTIMEOUT;                                      /* get tx buff time out         */
     }
-    uiTimeOut = 0;
+    uiTimeOut = micros;
     mcp2515_write_canMsg( txbuf_n);
     mcp2515_modifyRegister( txbuf_n-1 , MCP_TXB_TXREQ_M, MCP_TXB_TXREQ_M );
     
+    temp = micros();
     do
-    {
-        uiTimeOut++;        
+    {       
         res1 = mcp2515_readRegister(txbuf_n-1);                         /* read send buff ctrl reg 	*/
-        res1 = res1 & 0x08;                               		
+        res1 = res1 & 0x08;
+	uiTimeOut = micros() - temp;
     } while (res1 && (uiTimeOut < TIMEOUTVALUE));   
     
-    if(uiTimeOut == TIMEOUTVALUE)                                       /* send msg timeout             */	
+    if(uiTimeOut >= TIMEOUTVALUE)                                       /* send msg timeout             */	
         return CAN_SENDMSGTIMEOUT;
     
     return CAN_OK;

--- a/mcp_can.h
+++ b/mcp_can.h
@@ -38,6 +38,7 @@ class MCP_CAN
     INT8U   m_nDta[MAX_CHAR_IN_MESSAGE];                                // Data array
     INT8U   m_nRtr;                                                     // Remote request flag
     INT8U   m_nfilhit;                                                  // The number of the filter that matched the message
+    SPIClass *SPI;                                                       // The SPI-Device used
     INT8U   MCPCS;                                                      // Chip Select pin number
     INT8U   mcpMode;                                                    // Mode to return to after configurations are performed.
     
@@ -107,6 +108,7 @@ class MCP_CAN
 
 public:
     MCP_CAN(INT8U _CS);
+    MCP_CAN(SPIClass *_SPI, INT8U _CS);
     INT8U begin(INT8U idmodeset, INT8U speedset, INT8U clockset);       // Initialize controller parameters
     INT8U init_Mask(INT8U num, INT8U ext, INT32U ulData);               // Initialize Mask(s)
     INT8U init_Mask(INT8U num, INT32U ulData);                          // Initialize Mask(s)


### PR DESCRIPTION
Hi
I was using this library on an ESP32. Because of My setup I had to use the second SPI-Bus for the CAN transceiver. Now I have written a Constructor which can be used to pass the SPI-device the MCP is connected to
I hope, this can be useful for others. Tell me If I should provide an example
Best regards
bitconnector