### PR TITLE
Changed SPI speed to configurable

### DIFF
--- a/mcp_can.cpp
+++ b/mcp_can.cpp
@@ -32,7 +32,7 @@
 *********************************************************************************************************/
 void MCP_CAN::mcp2515_reset(void)                                      
 {
-    mcpSPI->beginTransaction(SPISettings(10000000, MSBFIRST, SPI_MODE0));
+    mcpSPI->beginTransaction(SPISettings(SPI_SPEED, MSBFIRST, SPI_MODE0));
     MCP2515_SELECT();
     spi_readwrite(MCP_RESET);
     MCP2515_UNSELECT();
@@ -48,7 +48,7 @@ INT8U MCP_CAN::mcp2515_readRegister(const INT8U address)
 {
     INT8U ret;
 
-    mcpSPI->beginTransaction(SPISettings(10000000, MSBFIRST, SPI_MODE0));
+    mcpSPI->beginTransaction(SPISettings(SPI_SPEED, MSBFIRST, SPI_MODE0));
     MCP2515_SELECT();
     spi_readwrite(MCP_READ);
     spi_readwrite(address);
@@ -66,7 +66,7 @@ INT8U MCP_CAN::mcp2515_readRegister(const INT8U address)
 void MCP_CAN::mcp2515_readRegisterS(const INT8U address, INT8U values[], const INT8U n)
 {
     INT8U i;
-    mcpSPI->beginTransaction(SPISettings(10000000, MSBFIRST, SPI_MODE0));
+    mcpSPI->beginTransaction(SPISettings(SPI_SPEED, MSBFIRST, SPI_MODE0));
     MCP2515_SELECT();
     spi_readwrite(MCP_READ);
     spi_readwrite(address);
@@ -84,7 +84,7 @@ void MCP_CAN::mcp2515_readRegisterS(const INT8U address, INT8U values[], const I
 *********************************************************************************************************/
 void MCP_CAN::mcp2515_setRegister(const INT8U address, const INT8U value)
 {
-    mcpSPI->beginTransaction(SPISettings(10000000, MSBFIRST, SPI_MODE0));
+    mcpSPI->beginTransaction(SPISettings(SPI_SPEED, MSBFIRST, SPI_MODE0));
     MCP2515_SELECT();
     spi_readwrite(MCP_WRITE);
     spi_readwrite(address);
@@ -100,7 +100,7 @@ void MCP_CAN::mcp2515_setRegister(const INT8U address, const INT8U value)
 void MCP_CAN::mcp2515_setRegisterS(const INT8U address, const INT8U values[], const INT8U n)
 {
     INT8U i;
-    mcpSPI->beginTransaction(SPISettings(10000000, MSBFIRST, SPI_MODE0));
+    mcpSPI->beginTransaction(SPISettings(SPI_SPEED, MSBFIRST, SPI_MODE0));
     MCP2515_SELECT();
     spi_readwrite(MCP_WRITE);
     spi_readwrite(address);
@@ -118,7 +118,7 @@ void MCP_CAN::mcp2515_setRegisterS(const INT8U address, const INT8U values[], co
 *********************************************************************************************************/
 void MCP_CAN::mcp2515_modifyRegister(const INT8U address, const INT8U mask, const INT8U data)
 {
-    mcpSPI->beginTransaction(SPISettings(10000000, MSBFIRST, SPI_MODE0));
+    mcpSPI->beginTransaction(SPISettings(SPI_SPEED, MSBFIRST, SPI_MODE0));
     MCP2515_SELECT();
     spi_readwrite(MCP_BITMOD);
     spi_readwrite(address);
@@ -135,7 +135,7 @@ void MCP_CAN::mcp2515_modifyRegister(const INT8U address, const INT8U mask, cons
 INT8U MCP_CAN::mcp2515_readStatus(void)                             
 {
     INT8U i;
-    mcpSPI->beginTransaction(SPISettings(10000000, MSBFIRST, SPI_MODE0));
+    mcpSPI->beginTransaction(SPISettings(SPI_SPEED, MSBFIRST, SPI_MODE0));
     MCP2515_SELECT();
     spi_readwrite(MCP_READ_STATUS);
     i = spi_read();

--- a/mcp_can.h
+++ b/mcp_can.h
@@ -26,6 +26,7 @@
 
 #include "mcp_can_dfs.h"
 #define MAX_CHAR_IN_MESSAGE 8
+#define SPI_SPEED 10000000
 
 class MCP_CAN
 {


### PR DESCRIPTION
Hello.

I modified SPI speed from the fixed value (10M) to the configurable with the `SPI_SPEED` definition in `mcp_can.h` .

In my environment, SPI with the speed of 10M didn't work but with slower speed (e.g. 1M, 4M) worked.
This PR makes it easier to change SPI speed in such a situation.

Hope this helps.