### PR TITLE
Added 10MHz crystal support

### DIFF
--- a/mcp_can.cpp
+++ b/mcp_can.cpp
@@ -329,6 +329,40 @@ INT8U MCP_CAN::mcp2515_configRate(const INT8U canSpeed, const INT8U canClock)
         }
         break;
 
+		case MCP_10MHZ:
+		switch (canSpeed)
+		{
+			case CAN_1000KBPS:
+			cfg1 = MCP_10MHz_1000kBPS_CFG1;
+			cfg2 = MCP_10MHz_1000kBPS_CFG2;
+			cfg3 = MCP_10MHz_1000kBPS_CFG3;
+			break;
+
+			case CAN_500KBPS:
+			cfg1 = MCP_10MHz_500kBPS_CFG1;
+			cfg2 = MCP_10MHz_500kBPS_CFG2;
+			cfg3 = MCP_10MHz_500kBPS_CFG3;
+			break;
+
+			case CAN_250KBPS:
+			cfg1 = MCP_10MHz_250kBPS_CFG1;
+			cfg2 = MCP_10MHz_250kBPS_CFG2;
+			cfg3 = MCP_10MHz_250kBPS_CFG3;
+			break;
+
+			case CAN_125KBPS:
+			cfg1 = MCP_10MHz_125kBPS_CFG1;
+			cfg2 = MCP_10MHz_125kBPS_CFG2;
+			cfg3 = MCP_10MHz_125kBPS_CFG3;
+			break;
+
+			default:
+			set = 0; // Unsupported baud rate for 10MHz
+		return MCP2515_FAIL;
+			break;
+		}
+		break;
+
         case (MCP_16MHZ):
         switch (canSpeed) 
         {

--- a/mcp_can_dfs.h
+++ b/mcp_can_dfs.h
@@ -308,6 +308,25 @@
 #define MCP_8MHz_5kBPS_CFG3 (0x84)     /* Sample point at 75% */
 
 /*
+** Add 10MHz configurations in mcp_can_dfs.h
+*/
+#define MCP_10MHz_1000kBPS_CFG1 (0x00)
+#define MCP_10MHz_1000kBPS_CFG2 (0xC8)
+#define MCP_10MHz_1000kBPS_CFG3 (0x80)
+
+#define MCP_10MHz_500kBPS_CFG1 (0x40)
+#define MCP_10MHz_500kBPS_CFG2 (0xD9)
+#define MCP_10MHz_500kBPS_CFG3 (0x82)
+
+#define MCP_10MHz_250kBPS_CFG1 (0x41)
+#define MCP_10MHz_250kBPS_CFG2 (0xD9)
+#define MCP_10MHz_250kBPS_CFG3 (0x82)
+
+#define MCP_10MHz_125kBPS_CFG1 (0x43)
+#define MCP_10MHz_125kBPS_CFG2 (0xD9)
+#define MCP_10MHz_125kBPS_CFG3 (0x82)
+
+/*
  *  speed 16M
  */
 #define MCP_16MHz_1000kBPS_CFG1 (0x00)
@@ -443,6 +462,7 @@
 #define MCP_20MHZ    0
 #define MCP_16MHZ    1
 #define MCP_8MHZ     2
+#define MCP_10MHZ     3
 #define MCP_CLOCK_SELECT 3
 #define MCP_CLKOUT_ENABLE 4
 


### PR DESCRIPTION
This update introduces configurations for the MCP_CAN library to support a 10MHz crystal oscillator. The following baud rates have been tested and verified with a MIKROE-986 CAN SPI Click 3.3V on an Arduino Nano 33 IoT, in communication with a CANBED v1 from Longan Labs:
- 125 kbps,
- 250 kbps
- 500 kbps
- 1000 kbps