### PR TITLE
function to reset overflow error bits

### DIFF
--- a/mcp_can.cpp
+++ b/mcp_can.cpp
@@ -1291,6 +1291,15 @@ INT8U MCP_CAN::getError(void)
 }
 
 /*********************************************************************************************************
+** Function name:           resetOverflowErrors
+** Descriptions:            Resets overflow error bits.
+*********************************************************************************************************/
+void MCP_CAN::resetOverflowErrors(void)
+{
+    mcp2515_modifyRegister(MCP_EFLG, MCP_EFLG_RX0OVR | MCP_EFLG_RX1OVR, 0);
+}
+
+/*********************************************************************************************************
 ** Function name:           mcp2515_errorCountRX
 ** Descriptions:            Returns REC register value
 *********************************************************************************************************/

--- a/mcp_can.h
+++ b/mcp_can.h
@@ -123,6 +123,7 @@ public:
     INT8U checkReceive(void);                                           // Check for received data
     INT8U checkError(void);                                             // Check for errors
     INT8U getError(void);                                               // Check for errors
+    void resetOverflowErrors(void);                                     // Reset overflow error bits
     INT8U errorCountRX(void);                                           // Get error count
     INT8U errorCountTX(void);                                           // Get error count
     INT8U enOneShotTX(void);                                            // Enable one-shot transmission


### PR DESCRIPTION
This PR adds a new function, `resetOverflowErrors()`. It resets the overflow error bits (`MCP_EFLG_RX0OVR` and `MCP_EFLG_RX1OVR`) in the `MCP_EFLG` register, ensuring that these flags can be cleared after an overflow event.

Example for overflow checking:
```cpp
uint8_t eflg = can.getError();
if ((eflg & MCP_EFLG_RX1OVR) || (eflg & MCP_EFLG_RX0OVR)) {
  Serial.println("buffer overflow!");
  can.resetOverflowErrors(); // new
}
```